### PR TITLE
Add optional flag to belongs_to

### DIFF
--- a/lib/ckeditor/orm/active_record.rb
+++ b/lib/ckeditor/orm/active_record.rb
@@ -14,7 +14,7 @@ module Ckeditor
             base.class_eval do
               self.table_name = 'ckeditor_assets'
 
-              belongs_to :assetable, polymorphic: true
+              belongs_to :assetable, polymorphic: true, optional: true
             end
           end
         end


### PR DESCRIPTION
Rails 5 now enforces all belongs_to associations to be required. This doesent allow picture creations unless optional is passed as true
